### PR TITLE
[bugfix] OS Win: Allow select single file for filedialpy.openFiles()

### DIFF
--- a/filedialpy/windows.py
+++ b/filedialpy/windows.py
@@ -48,6 +48,8 @@ def windows_wrapper(initial_dir=None,initial_file=None,filter=None,title=None,mu
         dirname=res[0]
         if len(res)>1:
             res = [os.path.join(dirname,x) for x in res[1:]]
+        elif res[0]=="":
+            res = []
     return res
 
 def openFile(initial_dir=None,initial_file=None,filter=None,title=None):
@@ -64,5 +66,5 @@ def openDir(title="Choose a folder",**kwargs):
     initial_pidl = shell.SHGetFolderLocation(hwnd, shellcon.CSIDL_DESKTOP, 0, 0)
     pidl, display_name, image_list = shell.SHBrowseForFolder(hwnd,initial_pidl,title, shellcon.ASSOCF_VERIFY,None, None)
     if pidl is not None: return shell.SHGetPathFromIDListW(pidl)
-
     else: return ""
+

--- a/filedialpy/windows.py
+++ b/filedialpy/windows.py
@@ -48,7 +48,6 @@ def windows_wrapper(initial_dir=None,initial_file=None,filter=None,title=None,mu
         dirname=res[0]
         if len(res)>1:
             res = [os.path.join(dirname,x) for x in res[1:]]
-        else: res=[]
     return res
 
 def openFile(initial_dir=None,initial_file=None,filter=None,title=None):
@@ -65,4 +64,5 @@ def openDir(title="Choose a folder",**kwargs):
     initial_pidl = shell.SHGetFolderLocation(hwnd, shellcon.CSIDL_DESKTOP, 0, 0)
     pidl, display_name, image_list = shell.SHBrowseForFolder(hwnd,initial_pidl,title, shellcon.ASSOCF_VERIFY,None, None)
     if pidl is not None: return shell.SHGetPathFromIDListW(pidl)
+
     else: return ""


### PR DESCRIPTION
**Issue:** When user calls `filedialpy.openFiles()` and select *single* file - `openFiles()` returns empty list

**Expectation:** `openFiles()` should returns list that contains single file when user selects single file

**Optional comment:**

When user select single file `GetOpenFileNameW` returns string with file full path without `\x00` delimeters, for example:
`res=win32gui.GetOpenFileNameW(Flags=win32con.OFN_ALLOWMULTISELECT  | win32con.OFN_EXPLORER)[0]`
returns full file path string: `C:\WINDOWS\explorer.exe`

**Result: So this fix allows Windows user select a single file when call `filedialpy.openFiles()`**