### PR TITLE
[minor ui] Use GetConsoleWindow() to get actual console window

### DIFF
--- a/filedialpy/windows.py
+++ b/filedialpy/windows.py
@@ -1,6 +1,7 @@
 import os
 import win32gui
 import win32con
+import win32console
 from win32com.shell import shell, shellcon
 
 
@@ -36,7 +37,7 @@ def windows_wrapper(initial_dir=None,initial_file=None,filter=None,title=None,mu
         
 
     try:
-        hwnd = win32gui.GetForegroundWindow()
+        hwnd = win32console.GetConsoleWindow()
         if save:
             res=win32gui.GetSaveFileNameW(hwndOwner=hwnd,**kwargs)[0]
         else:


### PR DESCRIPTION
Hi,

`GetForegroundWindow()` may return a handle to a window other than our console if we switch to another window while the Python script is running.

So I would suggest using `GetConsoleWindow()`, which always returns our console.

This also works correctly if the console is hidden (for example, if the script is run from an IDE) – the file selection dialog will still be visible (without owner window).

Thank you!