### PR TITLE
fix(macos): return empty result on dialog cancellation

### DIFF
--- a/filedialpy/mac.py
+++ b/filedialpy/mac.py
@@ -21,8 +21,11 @@ def mac_wrapper(initial_dir=None,initial_file=None,filter=None,
         cmd+=" of type {"+filter_string+"}"
     if multiple: cmd+=" with multiple selections allowed"
     #res=subprocess.run(["osascript","-"],input="the POSIX path of ("+cmd+")",text=True, capture_output=True)
-    res=subprocess.run(["osascript","-"],input=cmd,text=True, capture_output=True)
-    res=res.stdout.strip().split(",")
+    proc=subprocess.run(["osascript","-"],input=cmd,text=True, capture_output=True)
+    if proc.returncode != 0:
+        if multiple: return []
+        return ""
+    res=proc.stdout.strip().split(",")
     res=[x[x.find(":"):].replace(":","/") for x in res]
     res=[os.path.realpath(x) for x in res]
     if not multiple: res=res[0]


### PR DESCRIPTION
## Problem

On macOS, the backend could not distinguish a **cancelled** dialog from a genuine selection of the **current working directory**. When the user clicked Cancel, `osascript` exits non-zero (error `-128`) and writes the error to `stderr`, leaving `stdout` empty. The wrapper then ran `os.path.realpath("")` on that empty output, which resolves to the process working directory — so `openDir()` (and every other macOS dialog) returned the cwd instead of indicating cancellation.

This affected **all** macOS functions routed through `mac_wrapper`: `openFile`, `openFiles`, `openDir`, `openDirs`, and `saveFile`.

The other backends already handle cancellation correctly and consistently return `""` / `[]`:
- zenity: `linux_zenity.py`
- kdialog: `linux_kdialog.py`
- windows: `windows.py`

macOS was the lone outlier.

## Fix

Check `proc.returncode` before parsing stdout. On non-zero exit (cancellation), return `""` for single selection and `[]` for multiple — matching the other backends.

```python
proc=subprocess.run(["osascript","-"],input=cmd,text=True, capture_output=True)
if proc.returncode != 0:
    if multiple: return []
    return ""
res=proc.stdout.strip().split(",")
```

## Verification

- Cancel (returncode=1, empty stdout) → `""` (single) / `[]` (multiple) ✓
- Real selection (mocked + live `osascript`) → correct path ✓
- Genuinely selecting the cwd is no longer misreported as a cancel ✓

This also lets callers drop any macOS-specific cwd workaround (e.g. `os.path.realpath(path) == os.path.realpath("")`).

## Disclosure

The fix and PR was written using GLM-5.2, verified and tested manually by the author @ucodia.