### PR TITLE
fix(windows): support initial_dir in openDir

### DIFF
--- a/filedialpy/windows.py
+++ b/filedialpy/windows.py
@@ -61,10 +61,14 @@ def openFiles(initial_dir=None,initial_file=None,filter=None,title=None):
 def saveFile(initial_dir=None,initial_file=None,filter=None,title=None,confirm_overwrite=True):
     return windows_wrapper(initial_dir=initial_dir,initial_file=initial_file,filter=filter,title=title,save=True)
 
-def openDir(title="Choose a folder",**kwargs):
+def _browse_callback_proc(hwnd, msg, lp, data):
+    if msg == shellcon.BFFM_INITIALIZED:
+        win32gui.SendMessage(hwnd, shellcon.BFFM_SETSELECTIONW, 1, data)
+
+def openDir(initial_dir=None,initial_file=None,filter=None,title="Choose a folder"):
     hwnd = win32gui.GetForegroundWindow()
-    initial_pidl = shell.SHGetFolderLocation(hwnd, shellcon.CSIDL_DESKTOP, 0, 0)
-    pidl, display_name, image_list = shell.SHBrowseForFolder(hwnd,initial_pidl,title, shellcon.ASSOCF_VERIFY,None, None)
+    callback = _browse_callback_proc if initial_dir is not None else None
+    pidl, display_name, image_list = shell.SHBrowseForFolder(hwnd, None, title, shellcon.ASSOCF_VERIFY, callback, initial_dir)
     if pidl is not None: return shell.SHGetPathFromIDListW(pidl)
     else: return ""
 


### PR DESCRIPTION
## Problem
`openDir` on Windows ignored `initial_dir` — the only backend that did. macOS (`default location`), zenity (`--filename`), kdialog and tkinter (`initialdir`) all honored it, so the cross-platform contract was broken on Windows.

## Fix
Align the Windows `openDir` signature with the other backends:
```python
def openDir(initial_dir=None, initial_file=None, filter=None, title="Choose a folder"):
```
(the `title` default is kept to preserve existing Windows behavior).

When `initial_dir` is provided, a browse callback handles `BFFM_INITIALIZED` and sends `BFFM_SETSELECTIONW` (the Unicode variant) with the path, setting the initial selection **without** restricting browsing — matching the semantics of the other backends.

> The **Unicode** `BFFM_SETSELECTIONW` (`WM_USER + 103`) is used rather than the ANSI `BFFM_SETSELECTION` (`WM_USER + 102`). pywin32 marshals a Python `str` lParam as a pointer to its UTF-16 internal buffer; the ANSI variant interprets that pointer as a multibyte string, truncating/garbling the path so the selection is silently dropped. The Unicode variant interprets the pointer as a wide string, matching pywin32's buffer layout. Verified: ANSI → dialog opens at the default location; Unicode → opens at `initial_dir`.

When `initial_dir` is `None`, behavior is unchanged (root namespace = desktop, no callback).

## Behavior change
The first positional argument is now `initial_dir` (was `title`) to match the other backends. This only affects the undocumented, non-portable positional form `openDir("My Title")` (which on mac/linux already meant `initial_dir`); keyword usage (`openDir(title="My Title")`, `openDir(initial_dir=...)`) is unaffected.

## Result
All backends now honor `initial_dir` for `openDir`.

## Disclosure
The fix and PR was written using GLM-5.2, verified and tested manually by the author @ucodia.
